### PR TITLE
Only publish to flakehub from one architecture

### DIFF
--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -5,19 +5,8 @@ on:
       - "main"
 jobs:
   flakehub-publish:
-    name: publish to flakehub for ${{matrix.system}}
-    strategy:
-      matrix:
-        include:
-          - system: x86_64-linux
-            os: ubuntu-latest
-          - system: aarch64-linux
-            os: ubuntu-24.04-arm
-          - system: x86_64-darwin
-            os: macos-13
-          - system: aarch64-darwin
-            os: macos-latest
-    runs-on: ${{ matrix.os }}
+    name: publish to flakehub
+    runs-on: ubuntu-latest
     permissions:
       id-token: "write"
       contents: "read"


### PR DESCRIPTION
Your flake only needs to be published once from a single architecture to cover all architectures your flake supports. In other words: all you need to do to publish a flake that supports `x86_64-darwin` is run the `flakehub-push` action from any other architecture, like `x86_64-linux`.

Only a couple flakes actually pushed from macOS on macOS, so we're dropping support for publishing from that platform. But not to worry, you won't lose anything :).